### PR TITLE
Added support for `POST /withdrawals/crypto` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,16 @@ rest_api.withdraw(wallet_id, 10) do |resp|
 end
 ```
 
+**crypto_withdrawal**
+
+Withdraw money to a crypto address
+
+```ruby
+rest_api.crypto_withdrawal(10, 'BTC', 'a365117a-8e67-4de2-9655-21ec5cf2211e') do |resp|
+  p "Withdrew 10 BTC to BTC wallet with address a365117a-8e67-4de2-9655-21ec5cf2211e"
+end
+```
+
 ### Other
 
 **server_time**

--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -242,6 +242,19 @@ module Coinbase
         out
       end
 
+      def crypto_withdrawal(amount, currency, crypto_address, params = {})
+        params[:amount] = amount
+        params[:currency] = currency
+        params[:crypto_address] = crypto_address
+
+        out = nil
+        post("/withdrawals/crypto", params) do |resp|
+          out = response_object(resp)
+          yield(out, resp) if block_given?
+        end
+        out
+      end
+
       private
 
       def response_collection(resp)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,8 @@ ORDER_REFS    = [ :bid,
                   :fills ]
 
 TRANSFER_REFS = [ :deposit,
-                  :withdraw ]
+                  :withdraw,
+                  :crypto_withdrawal ]
 
 def endpoints
   (MARKET_REFS << ACCOUNT_REFS << ORDER_REFS << TRANSFER_REFS).flatten!

--- a/spec/synchronous_spec.rb
+++ b/spec/synchronous_spec.rb
@@ -181,4 +181,15 @@ describe Coinbase::Exchange::Client do
       expect(out['status']).to eq('OK')
     end
   end
+
+  it "makes a withdrawal to a crypto address" do
+    crypto_address = SecureRandom.uuid
+    stub_request(:post, /withdrawals.crypto/)
+      .with(body: {amount: 1.5, currency: 'BTC', crypto_address: crypto_address})
+      .to_return(body: mock_item.to_json)
+    @client.crypto_withdrawal(1.5, 'BTC', crypto_address) do |out|
+      expect(out.class).to eq(Coinbase::Exchange::APIObject)
+      expect(out['status']).to eq('OK')
+    end
+  end
 end


### PR DESCRIPTION
## Added
* Support for `POST /withdrawals/crypto` endpoint allowing users to withdraw crypto currency from GDax to another crypto wallet