### PR TITLE
Additional withdrawal methods

### DIFF
--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -242,6 +242,36 @@ module Coinbase
         out
       end
 
+      #
+      # Withdrawals
+      #
+
+      def payment_method_withdrawal(amount, currency, payment_method_id, params = {})
+        params[:amount] = amount
+        params[:currency] = currency
+        params[:payment_method_id] = payment_method_id
+
+        out = nil
+        post("/withdrawals/payment-method", params) do |resp|
+          out = response_object(resp)
+          yield(out, resp) if block_given?
+        end
+        out
+      end
+
+      def coinbase_withdrawal(amount, currency, coinbase_account_id, params = {})
+        params[:amount] = amount
+        params[:currency] = currency
+        params[:coinbase_account_id] = coinbase_account_id
+
+        out = nil
+        post("/withdrawals/coinbase-account", params) do |resp|
+          out = response_object(resp)
+          yield(out, resp) if block_given?
+        end
+        out
+      end
+
       def crypto_withdrawal(amount, currency, crypto_address, params = {})
         params[:amount] = amount
         params[:currency] = currency

--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -285,6 +285,30 @@ module Coinbase
         out
       end
 
+      #
+      # Payment Methods
+      #
+      def payment_methods(params = {})
+        out = nil
+        get("/payment-methods", params, paginate: true) do |resp|
+          out = response_collection(resp)
+          yield(out, resp) if block_given?
+        end
+        out
+      end
+
+      #
+      # Coinbase Accounts
+      #
+      def coinbase_accounts(params = {})
+        out = nil
+        get("/coinbase-accounts", params, paginate: true) do |resp|
+          out = response_collection(resp)
+          yield(out, resp) if block_given?
+        end
+        out
+      end
+
       private
 
       def response_collection(resp)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,9 @@ MARKET_REFS   = [ :currencies,
 ACCOUNT_REFS  = [ :accounts,
                   :account,
                   :account_history,
-                  :account_holds ]
+                  :account_holds,
+                  :payment_methods,
+                  :coinbase_accounts ]
 
 ORDER_REFS    = [ :bid,
                   :ask,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,8 @@ ORDER_REFS    = [ :bid,
 
 TRANSFER_REFS = [ :deposit,
                   :withdraw,
+                  :payment_method_withdrawal,
+                  :coinbase_withdrawal,
                   :crypto_withdrawal ]
 
 def endpoints

--- a/spec/synchronous_spec.rb
+++ b/spec/synchronous_spec.rb
@@ -182,6 +182,28 @@ describe Coinbase::Exchange::Client do
     end
   end
 
+  it "makes a withdrawal to a payment method" do
+    payment_method_id = SecureRandom.uuid
+    stub_request(:post, /withdrawals.payment-method/)
+      .with(body: {amount: 1.5, currency: 'BTC', payment_method_id: payment_method_id})
+      .to_return(body: mock_item.to_json)
+    @client.payment_method_withdrawal(1.5, 'BTC', payment_method_id) do |out|
+      expect(out.class).to eq(Coinbase::Exchange::APIObject)
+      expect(out['status']).to eq('OK')
+    end
+  end
+
+  it "makes a withdrawal to a Coinbase account" do
+    coinbase_account_id = SecureRandom.uuid
+    stub_request(:post, /withdrawals.coinbase-account/)
+      .with(body: {amount: 1.5, currency: 'BTC', coinbase_account_id: coinbase_account_id})
+      .to_return(body: mock_item.to_json)
+    @client.coinbase_withdrawal(1.5, 'BTC', coinbase_account_id) do |out|
+      expect(out.class).to eq(Coinbase::Exchange::APIObject)
+      expect(out['status']).to eq('OK')
+    end
+  end
+
   it "makes a withdrawal to a crypto address" do
     crypto_address = SecureRandom.uuid
     stub_request(:post, /withdrawals.crypto/)
@@ -192,4 +214,6 @@ describe Coinbase::Exchange::Client do
       expect(out['status']).to eq('OK')
     end
   end
+
+
 end

--- a/spec/synchronous_spec.rb
+++ b/spec/synchronous_spec.rb
@@ -215,5 +215,24 @@ describe Coinbase::Exchange::Client do
     end
   end
 
+  it "gets payment methods" do
+    stub_request(:get, /payment-methods/).to_return(body: mock_collection.to_json)
+    @client.payment_methods do |out|
+      out.each do |item|
+        expect(item.class).to eq(Coinbase::Exchange::APIObject)
+        expect(item['status']).to eq('OK')
+      end
+    end
+  end
+
+  it "gets Coinbase accounts" do
+    stub_request(:get, /coinbase-accounts/).to_return(body: mock_collection.to_json)
+    @client.coinbase_accounts do |out|
+      out.each do |item|
+        expect(item.class).to eq(Coinbase::Exchange::APIObject)
+        expect(item['status']).to eq('OK')
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
## Added
* Support for `POST /withdrawals/payment-method` endpoint
* Support for `POST /withdrawals/coinbase-account` endpoint
* Support for `GET /payment-methods` endpoint
* Support for `GET /coinbase-accounts` endpoint